### PR TITLE
Conversion of torch.Tensor to numpy object

### DIFF
--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import logging
 import numpy as np
+import torch
 
 class Logger:
     def __init__(self, console_logger):
@@ -45,7 +46,7 @@ class Logger:
                 continue
             i += 1
             window = 5 if k != "epsilon" else 1
-            item = "{:.4f}".format(np.mean([x[1] for x in self.stats[k][-window:]]))
+            item = "{:.4f}".format(np.mean([x[1] if not isinstance(x[1], torch.Tensor) else x[1].cpu().numpy() for x in self.stats[k][-window:]]))
             log_str += "{:<25}{:>8}".format(k + ":", item)
             log_str += "\n" if i % 4 == 0 else "\t"
         self.console_logger.info(log_str)


### PR DESCRIPTION
Due to the possibility of `x[1]` being of type `torch.Tensor`, the `np.mean(...)` call fails with an `AttributeError: torch.dtype object has no attribute type`.

The full error is

`[ERROR 03:50:05] pymarl Failed after 0:01:46!
Traceback (most recent calls WITHOUT Sacred internals):
  File "src/main.py", line 35, in my_main
    run(_run, config, _log)
  File "/home/minerva/Projects/multiagentrl/pymarl/src/run.py", line 48, in run
    run_sequential(args=args, logger=logger)
  File "/home/minerva/Projects/multiagentrl/pymarl/src/run.py", line 209, in run_sequential
    logger.print_recent_stats()
  File "/home/minerva/Projects/multiagentrl/pymarl/src/utils/logging.py", line 48, in print_recent_stats
    item = "{:.4f}".format(np.mean([x[1] for x in self.stats[k][-window:]]))
  File "<__array_function__ internals>", line 6, in mean
  File "/home/minerva/anaconda3/envs/mpe/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 3335, in mean
    out=out, **kwargs)
  File "/home/minerva/anaconda3/envs/mpe/lib/python3.6/site-packages/numpy/core/_methods.py", line 161, in _mean
    ret = ret.dtype.type(ret / rcount)
AttributeError: 'torch.dtype' object has no attribute 'type'
[INFO 03:50:05] absl Shutdown gracefully.
[INFO 03:50:05] absl Shutdown with return code: -15
`