### PR TITLE
Fix memory leak

### DIFF
--- a/src/runners/episode_runner.py
+++ b/src/runners/episode_runner.py
@@ -65,12 +65,13 @@ class EpisodeRunner:
             # Pass the entire batch of experiences up till now to the agents
             # Receive the actions for each agent at this timestep in a batch of size 1
             actions = self.mac.select_actions(self.batch, t_ep=self.t, t_env=self.t_env, test_mode=test_mode)
+            cpu_actions = actions.to("cpu").numpy()
 
-            reward, terminated, env_info = self.env.step(actions[0])
+            reward, terminated, env_info = self.env.step(cpu_actions[0])
             episode_return += reward
 
             post_transition_data = {
-                "actions": actions,
+                "actions": cpu_actions,
                 "reward": [(reward,)],
                 "terminated": [(terminated != env_info.get("episode_limit", False),)],
             }
@@ -88,7 +89,8 @@ class EpisodeRunner:
 
         # Select actions in the last stored state
         actions = self.mac.select_actions(self.batch, t_ep=self.t, t_env=self.t_env, test_mode=test_mode)
-        self.batch.update({"actions": actions}, ts=self.t)
+        cpu_actions = actions.to("cpu").numpy()
+        self.batch.update({"actions": cpu_actions}, ts=self.t)
 
         cur_stats = self.test_stats if test_mode else self.train_stats
         cur_returns = self.test_returns if test_mode else self.train_returns

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -49,6 +49,8 @@ class Logger:
             log_str += "{:<25}{:>8}".format(k + ":", item)
             log_str += "\n" if i % 4 == 0 else "\t"
         self.console_logger.info(log_str)
+        # Reset stats to avoid accumulating logs in memory
+        self.stats = defaultdict(lambda: [])
 
 
 # set up a custom logger


### PR DESCRIPTION
- In EpisodeRunner, the `actions` should either be detached from the computation graph or be converted into a numpy array before being stored into the replay buffer. In the original code, the entire computation graph for generating the action isn't released and consume unnecessary amount of memory. And may cause OOM if the program has been ran for a long time.
- In Logger, the stats should be cleared periodically to avoid accumulating unnecessary logs in the memory.