### PR TITLE
Avoid `AttributeError: 'torch.dtype' object has no attribute 'type'` …

### DIFF
--- a/src/components/episode_buffer.py
+++ b/src/components/episode_buffer.py
@@ -1,3 +1,5 @@
+import numbers
+
 import torch as th
 import numpy as np
 from types import SimpleNamespace as SN
@@ -60,7 +62,7 @@ class EpisodeBatch:
             group = field_info.get("group", None)
             dtype = field_info.get("dtype", th.float32)
 
-            if isinstance(vshape, int):
+            if isinstance(vshape, numbers.Integral):
                 vshape = (vshape,)
 
             if group:

--- a/src/components/episode_buffer.py
+++ b/src/components/episode_buffer.py
@@ -102,7 +102,7 @@ class EpisodeBatch:
                 raise KeyError("{} not found in transition or episode data".format(k))
 
             dtype = self.scheme[k].get("dtype", th.float32)
-            v = th.tensor(v, dtype=dtype, device=self.device)
+            v = th.as_tensor(v, dtype=dtype, device=self.device)
             self._check_safe_view(v, target[k][_slices])
             target[k][_slices] = v.view_as(target[k][_slices])
 

--- a/src/learners/coma_learner.py
+++ b/src/learners/coma_learner.py
@@ -93,7 +93,7 @@ class COMALearner:
 
             self.logger.log_stat("advantage_mean", (advantages * mask).sum().item() / mask.sum().item(), t_env)
             self.logger.log_stat("coma_loss", coma_loss.item(), t_env)
-            self.logger.log_stat("agent_grad_norm", grad_norm, t_env)
+            self.logger.log_stat("agent_grad_norm", grad_norm.item(), t_env)
             self.logger.log_stat("pi_max", (pi.max(dim=1)[0] * mask).sum().item() / mask.sum().item(), t_env)
             self.log_stats_t = t_env
 

--- a/src/learners/q_learner.py
+++ b/src/learners/q_learner.py
@@ -108,7 +108,7 @@ class QLearner:
 
         if t_env - self.log_stats_t >= self.args.learner_log_interval:
             self.logger.log_stat("loss", loss.item(), t_env)
-            self.logger.log_stat("grad_norm", grad_norm, t_env)
+            self.logger.log_stat("grad_norm", grad_norm.item(), t_env)
             mask_elems = mask.sum().item()
             self.logger.log_stat("td_error_abs", (masked_td_error.abs().sum().item()/mask_elems), t_env)
             self.logger.log_stat("q_taken_mean", (chosen_action_qvals * mask).sum().item()/(mask_elems * self.args.n_agents), t_env)

--- a/src/learners/qtran_learner.py
+++ b/src/learners/qtran_learner.py
@@ -142,7 +142,7 @@ class QLearner:
             self.logger.log_stat("td_loss", td_loss.item(), t_env)
             self.logger.log_stat("opt_loss", opt_loss.item(), t_env)
             self.logger.log_stat("nopt_loss", nopt_loss.item(), t_env)
-            self.logger.log_stat("grad_norm", grad_norm, t_env)
+            self.logger.log_stat("grad_norm", grad_norm.item(), t_env)
             if self.args.mixer == "qtran_base":
                 mask_elems = mask.sum().item()
                 self.logger.log_stat("td_error_abs", (masked_td_error.abs().sum().item()/mask_elems), t_env)


### PR DESCRIPTION
Avoid `AttributeError: 'torch.dtype' object has no attribute 'type'` error. To make it compatible with new PyTorch versions